### PR TITLE
Replace URL entry with file picker

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,15 +4,26 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>PowerBookmarks</title>
+    <style>
+        #folder-selector {
+            position: absolute;
+            top: 10px;
+            right: 10px;
+        }
+
+        #selected-folder {
+            margin-left: 10px;
+        }
+    </style>
 </head>
 <body>
 
     <h1>PowerBookmarks</h1>
-    <div id="new-bookmark">
-        <input type="text" id="bookmark-input" placeholder="Enter a URL" />
-        <button id="add-btn">Add Bookmark</button>
+    <div id="folder-selector">
+        <input type="file" id="folder-input" style="display: none;" webkitdirectory directory />
+        <button id="choose-folder">Choose Folder</button>
+        <span id="selected-folder"></span>
     </div>
-    <ul id="bookmark-list"></ul>
 
     <script src="renderer.js"></script>
 

--- a/renderer.js
+++ b/renderer.js
@@ -1,15 +1,19 @@
 window.addEventListener('DOMContentLoaded', () => {
-    const input = document.getElementById('bookmark-input');
-    const list = document.getElementById('bookmark-list');
-    const addBtn = document.getElementById('add-btn');
+    const folderInput = document.getElementById('folder-input');
+    const chooseBtn = document.getElementById('choose-folder');
+    const selected = document.getElementById('selected-folder');
 
-    addBtn.addEventListener('click', () => {
-        const url = input.value.trim();
-        if (url) {
-            const li = document.createElement('li');
-            li.textContent = url;
-            list.appendChild(li);
-            input.value = '';
+    chooseBtn.addEventListener('click', () => {
+        folderInput.click();
+    });
+
+    folderInput.addEventListener('change', () => {
+        if (folderInput.files.length > 0) {
+            const path = folderInput.files[0].webkitRelativePath;
+            const folderName = path.split('/')[0];
+            selected.textContent = folderName;
+        } else {
+            selected.textContent = '';
         }
     });
 


### PR DESCRIPTION
## Summary
- remove old bookmark input controls
- add a folder picker button at the top-right with styling
- display selected folder name next to the button
- update renderer logic to handle choosing folders

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686329468654832690bc4654368d9486