### PR TITLE
Use title from visual.json for visual names

### DIFF
--- a/renderer.js
+++ b/renderer.js
@@ -98,7 +98,16 @@ async function showBookmarkDetails(container, bookmarkFolder, bookmarkName) {
             const content = await fs.readFile(visualPath, 'utf-8');
             const visualData = JSON.parse(content);
 
-            const displayName = visualData?.visual?.visualContainerObjects?.title?.[0]?.properties?.text?.expr?.literal?.value;
+
+            const titleObject = visualData?.visual?.visualContainerObjects?.title?.[0];
+
+            const titleExpr = titleObject?.properties?.text?.expr?.Literal?.Value;
+
+            const displayName = titleExpr?.replace(/^'(.*)'$/, '$1');
+            console.log('titleObject:', titleObject);
+            console.log('titleExpr:', titleExpr);
+
+            console.log(displayName); // should output: Title on visual but not turned on
 
             visualMap.set(folderName, {
               id: folderName,

--- a/renderer.js
+++ b/renderer.js
@@ -97,9 +97,12 @@ async function showBookmarkDetails(container, bookmarkFolder, bookmarkName) {
           try {
             const content = await fs.readFile(visualPath, 'utf-8');
             const visualData = JSON.parse(content);
+
+            const displayName = visualData?.visual?.visualContainerObjects?.title?.[0]?.properties?.text?.expr?.literal?.value;
+
             visualMap.set(folderName, {
               id: folderName,
-              name: visualData.name || folderName,
+              name: displayName || visualData.name || folderName,
               parent: visualData.parentGroupName || null,
               children: []
             });


### PR DESCRIPTION
## Summary
- resolve visual title from `visual.json` when reading visuals

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866fdb0e02083269061942e2c5dcc03