### PR TITLE
Add expand/collapse all toggle

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,19 @@
       transform: scale(1.05);
     }
 
+    #toggle-all {
+      background: #f0f0f0;
+      border: 1px solid #ccc;
+      padding: 4px 8px;
+      border-radius: 4px;
+      cursor: pointer;
+      transition: background 0.2s ease;
+    }
+
+    #toggle-all:hover {
+      background: #e0e0e0;
+    }
+
     #selected-folder {
       font-weight: bold;
       color: #fff;
@@ -162,7 +175,10 @@
 
   <div class="main">
     <div class="column">
-      <h3>Bookmarks</h3>
+      <div style="display:flex; align-items:center; justify-content:space-between;">
+        <h3 style="margin:0;">Bookmarks</h3>
+        <button id="toggle-all">Expand All</button>
+      </div>
       <div class="scroll-box">
         <ul id="bookmark-list"></ul>
       </div>

--- a/renderer.js
+++ b/renderer.js
@@ -205,7 +205,33 @@ window.addEventListener('DOMContentLoaded', () => {
   const selected = document.getElementById('selected-folder');
   const list = document.getElementById('bookmark-list');
   const detailEl = document.getElementById('bookmark-details');
+  const toggleAllBtn = document.getElementById('toggle-all');
   let activeBookmarkEl = null;
+  let allCollapsed = true;
+
+  function setAllCollapsed(collapsed) {
+    const containers = document.querySelectorAll('.children-container');
+    containers.forEach(container => {
+      if (collapsed) {
+        container.classList.add('hidden');
+      } else {
+        container.classList.remove('hidden');
+      }
+      const icon = container.previousElementSibling?.querySelector('.toggle-icon');
+      if (icon) {
+        icon.textContent = collapsed ? '▼' : '▲';
+      }
+    });
+    toggleAllBtn.textContent = collapsed ? 'Expand All' : 'Collapse All';
+  }
+
+  // Initialize UI in collapsed state
+  setAllCollapsed(allCollapsed);
+
+  toggleAllBtn.addEventListener('click', () => {
+    allCollapsed = !allCollapsed;
+    setAllCollapsed(allCollapsed);
+  });
 
   function setActive(el) {
     if (activeBookmarkEl) {
@@ -226,6 +252,10 @@ window.addEventListener('DOMContentLoaded', () => {
     selected.textContent = path.basename(folderPath);
     setActive(null);
     chooseBtn.textContent = 'Change Project';
+
+    // Reset collapsed state for the new project
+    allCollapsed = true;
+    setAllCollapsed(allCollapsed);
 
     const bookmarksFile = await findBookmarksJson(folderPath);
     if (!bookmarksFile) {
@@ -337,6 +367,9 @@ window.addEventListener('DOMContentLoaded', () => {
           pageIcon.textContent = hidden ? '▼' : '▲';
         });
       }
+
+      // Apply global collapse state to new elements
+      setAllCollapsed(allCollapsed);
     } catch (e) {
       console.error('Failed to read bookmarks.json:', e);
       list.textContent = 'Failed to load bookmarks';


### PR DESCRIPTION
## Summary
- add global collapse/expand button in bookmarks panel
- implement logic to show or hide all bookmark groups with one click
- default to collapsed state when app starts and when selecting a new project

## Testing
- `npm test` *(fails: no test script)*

------
https://chatgpt.com/codex/tasks/task_e_68671863c07883268261d93e3754676d