### PR TITLE
Add Visual Details column and resizable sidebar

### DIFF
--- a/index.html
+++ b/index.html
@@ -28,7 +28,7 @@
       display: flex;
       gap: 30px;
       flex: 1;
-      padding: 20px;
+      padding: 20px 20px 0 20px;
       overflow: visible;
     }
 
@@ -39,6 +39,11 @@
       overflow: hidden;
     }
 
+    #details-column,
+    #visual-column {
+      padding-bottom: 20px;
+    }
+
     #bookmark-column {
       width: 325px;
       flex: none;
@@ -47,7 +52,7 @@
       position: relative;
       background: #fff;
       box-shadow: 2px 0 4px rgba(0,0,0,0.1);
-      margin: -20px 0 -20px -20px;
+      margin: -20px 0 0 -20px;
       padding: 20px;
       box-sizing: border-box;
     }

--- a/index.html
+++ b/index.html
@@ -39,6 +39,28 @@
       overflow: hidden;
     }
 
+    #bookmark-column {
+      width: 220px;
+      flex: none;
+      min-width: 150px;
+      max-width: 600px;
+      position: relative;
+    }
+
+    #bookmark-resizer {
+      position: absolute;
+      top: 0;
+      right: 0;
+      bottom: 0;
+      width: 5px;
+      cursor: ew-resize;
+      background: #ddd;
+    }
+
+    #visual-column {
+      display: none;
+    }
+
     .column h3 {
       margin: 0 0 10px 0;
     }
@@ -240,7 +262,7 @@
   </div>
 
   <div class="main">
-    <div class="column">
+    <div class="column" id="bookmark-column">
       <div class="bookmark-header">
         <h3 style="margin:0;">Bookmarks</h3>
         <button id="toggle-all">Expand All</button>
@@ -248,8 +270,9 @@
       <div class="scroll-box">
         <ul id="bookmark-list"></ul>
       </div>
+      <div id="bookmark-resizer"></div>
     </div>
-    <div class="column">
+    <div class="column" id="details-column">
       <div class="bookmark-header">
         <h3 style="margin:0;">Bookmark Details</h3>
       </div>
@@ -260,6 +283,14 @@
       </div>
       <div class="scroll-box">
         <div id="bookmark-details"></div>
+      </div>
+    </div>
+    <div class="column" id="visual-column">
+      <div class="bookmark-header">
+        <h3 style="margin:0;">Visual Details</h3>
+      </div>
+      <div class="scroll-box">
+        <div id="visual-details"></div>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -40,11 +40,13 @@
     }
 
     #bookmark-column {
-      width: 220px;
+      width: 250px;
       flex: none;
       min-width: 150px;
       max-width: 600px;
       position: relative;
+      background: #fff;
+      box-shadow: 2px 0 4px rgba(0,0,0,0.1);
     }
 
     #bookmark-resizer {
@@ -54,7 +56,6 @@
       bottom: 0;
       width: 5px;
       cursor: ew-resize;
-      background: #ddd;
     }
 
     #visual-column {

--- a/index.html
+++ b/index.html
@@ -47,18 +47,16 @@
       position: relative;
       background: #fff;
       box-shadow: 2px 0 4px rgba(0,0,0,0.1);
-      margin-left: -20px;
-      margin-top: 0;
-      margin-bottom: -20px;
+      margin: 0;
       padding: 20px;
       box-sizing: border-box;
     }
 
     #bookmark-resizer {
       position: absolute;
-      top: -20px;
+      top: 0;
       right: -2px;
-      bottom: -20px;
+      bottom: 0;
       width: 5px;
       cursor: ew-resize;
     }

--- a/index.html
+++ b/index.html
@@ -47,6 +47,9 @@
       position: relative;
       background: #fff;
       box-shadow: 2px 0 4px rgba(0,0,0,0.1);
+      margin-left: -20px;
+      margin-top: -20px;
+      margin-bottom: -20px;
     }
 
     #bookmark-resizer {

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       gap: 30px;
       flex: 1;
       padding: 20px;
-      overflow: hidden;
+      overflow: visible;
     }
 
     .column {
@@ -47,7 +47,7 @@
       position: relative;
       background: #fff;
       box-shadow: 2px 0 4px rgba(0,0,0,0.1);
-      margin: 0;
+      margin: -20px 0 -20px -20px;
       padding: 20px;
       box-sizing: border-box;
     }

--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
       gap: 30px;
       flex: 1;
       padding: 20px 20px 0 20px;
-      overflow: visible;
+      overflow: hidden;
     }
 
     .column {

--- a/index.html
+++ b/index.html
@@ -48,17 +48,17 @@
       background: #fff;
       box-shadow: 2px 0 4px rgba(0,0,0,0.1);
       margin-left: -20px;
-      margin-top: -20px;
+      margin-top: 0;
       margin-bottom: -20px;
-      padding: 0 20px 20px 20px;
+      padding: 20px;
       box-sizing: border-box;
     }
 
     #bookmark-resizer {
       position: absolute;
-      top: 0;
+      top: -20px;
       right: -2px;
-      bottom: 0;
+      bottom: -20px;
       width: 5px;
       cursor: ew-resize;
     }

--- a/index.html
+++ b/index.html
@@ -40,7 +40,7 @@
     }
 
     #bookmark-column {
-      width: 250px;
+      width: 325px;
       flex: none;
       min-width: 150px;
       max-width: 600px;
@@ -50,12 +50,14 @@
       margin-left: -20px;
       margin-top: -20px;
       margin-bottom: -20px;
+      padding: 0 20px 20px 20px;
+      box-sizing: border-box;
     }
 
     #bookmark-resizer {
       position: absolute;
       top: 0;
-      right: 0;
+      right: -2px;
       bottom: 0;
       width: 5px;
       cursor: ew-resize;

--- a/renderer.js
+++ b/renderer.js
@@ -212,7 +212,11 @@ async function showBookmarkDetails(metaContainer, container, bookmarkFolder, boo
 
             visualDiv.addEventListener('click', (e) => {
               e.stopPropagation();
-              setActiveVisual(visualDiv);
+              if (activeVisualEl === visualDiv) {
+                setActiveVisual(null);
+              } else {
+                setActiveVisual(visualDiv);
+              }
               const hidden = childContainer.classList.toggle('hidden');
               icon.textContent = hidden ? '▼' : '▲';
             });
@@ -225,7 +229,11 @@ async function showBookmarkDetails(metaContainer, container, bookmarkFolder, boo
           } else {
             visualDiv.addEventListener('click', (e) => {
               e.stopPropagation();
-              setActiveVisual(visualDiv);
+              if (activeVisualEl === visualDiv) {
+                setActiveVisual(null);
+              } else {
+                setActiveVisual(visualDiv);
+              }
             });
           }
 

--- a/renderer.js
+++ b/renderer.js
@@ -3,6 +3,9 @@ const path = require('path');
 const { ipcRenderer } = require('electron');
 
 let activeVisualEl = null;
+let visualColumn = null;
+let visualDetailsEl = null;
+const visualInfoMap = new WeakMap();
 
 function setActiveVisual(el) {
   if (activeVisualEl) {
@@ -11,6 +14,19 @@ function setActiveVisual(el) {
   activeVisualEl = el;
   if (activeVisualEl) {
     activeVisualEl.classList.add('active');
+    if (visualColumn && visualDetailsEl) {
+      visualColumn.style.display = 'flex';
+      const info = visualInfoMap.get(activeVisualEl);
+      if (info) {
+        visualDetailsEl.textContent = JSON.stringify(info.data, null, 2);
+      } else {
+        visualDetailsEl.textContent = '';
+      }
+    }
+  }
+  if (!activeVisualEl && visualColumn && visualDetailsEl) {
+    visualColumn.style.display = 'none';
+    visualDetailsEl.textContent = '';
   }
 }
 
@@ -139,12 +155,13 @@ async function showBookmarkDetails(metaContainer, container, bookmarkFolder, boo
 
             console.log(displayName); // should output: Title on visual but not turned on
 
-            visualMap.set(folderName, {
-              id: folderName,
-              name: displayName || visualData.name || folderName,
-              parent: visualData.parentGroupName || null,
-              children: []
-            });
+              visualMap.set(folderName, {
+                id: folderName,
+                name: displayName || visualData.name || folderName,
+                parent: visualData.parentGroupName || null,
+                children: [],
+                data: visualData
+              });
           } catch (e) {
             console.warn(`Failed to load visual: ${folderName}`, e.message);
           }
@@ -172,6 +189,7 @@ async function showBookmarkDetails(metaContainer, container, bookmarkFolder, boo
           const visualDiv = document.createElement('div');
           visualDiv.className = 'bookmark-item visual-item';
           visualDiv.style.marginLeft = `${depth * 20}px`;
+          visualInfoMap.set(visualDiv, visual);
 
           if (applyOnly && targetNames.has(visual.id)) {
             visualDiv.classList.add('target-visual');
@@ -260,6 +278,10 @@ window.addEventListener('DOMContentLoaded', () => {
   const list = document.getElementById('bookmark-list');
   const detailEl = document.getElementById('bookmark-details');
   const metaEl = document.getElementById('bookmark-meta');
+  visualColumn = document.getElementById('visual-column');
+  visualDetailsEl = document.getElementById('visual-details');
+  const bookmarkColumn = document.getElementById('bookmark-column');
+  const bookmarkResizer = document.getElementById('bookmark-resizer');
   const toggleAllBtn = document.getElementById('toggle-all');
   const toggleVisualsBtn = document.getElementById('toggle-visuals');
   let activeBookmarkEl = null;
@@ -315,6 +337,23 @@ window.addEventListener('DOMContentLoaded', () => {
   toggleVisualsBtn.addEventListener('click', () => {
     visualsCollapsed = !visualsCollapsed;
     setVisualsCollapsed(visualsCollapsed);
+  });
+
+  let resizing = false;
+  bookmarkResizer.addEventListener('mousedown', (e) => {
+    e.preventDefault();
+    resizing = true;
+  });
+
+  window.addEventListener('mousemove', (e) => {
+    if (!resizing) return;
+    const rect = bookmarkColumn.getBoundingClientRect();
+    const newWidth = e.clientX - rect.left;
+    bookmarkColumn.style.width = Math.min(Math.max(newWidth, 150), 600) + 'px';
+  });
+
+  window.addEventListener('mouseup', () => {
+    resizing = false;
   });
 
   function setActive(el) {


### PR DESCRIPTION
## Summary
- add optional Visual Details column
- make bookmarks column narrower and resizable
- show/hide visual details when a visual is selected

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686aabbd8fd48326a21d3fec106ddb4a