### PR TITLE
Add styled tooltip for visual fields

### DIFF
--- a/index.html
+++ b/index.html
@@ -259,6 +259,19 @@
       font-weight: bold;
       color: #fff;
     }
+
+    #tooltip {
+      position: absolute;
+      display: none;
+      pointer-events: none;
+      background: #fff;
+      color: #000;
+      padding: 6px 8px;
+      border-radius: 4px;
+      box-shadow: 0 2px 6px rgba(0,0,0,0.2);
+      font-size: 12px;
+      z-index: 1000;
+    }
   </style>
 </head>
 <body>
@@ -303,6 +316,8 @@
       </div>
     </div>
   </div>
+
+  <div id="tooltip"></div>
 
   <script src="renderer.js"></script>
 </body>

--- a/renderer.js
+++ b/renderer.js
@@ -41,6 +41,14 @@ function parseField(obj) {
     property = obj.field.Hierarchy.Hierarchy;
   }
 
+  // Fallback for Aggregation -> Column pattern (implicit measures)
+  if (!entity && !property && obj.field?.Aggregation?.Expression?.Column) {
+    fieldType = 'Implicit Measure';
+    entity =
+      obj.field.Aggregation.Expression.Column.Expression?.SourceRef?.Entity;
+    property = obj.field.Aggregation.Expression.Column.Property;
+  }
+
   const label = obj.label || property;
   const tooltipParts = [];
   if (entity) tooltipParts.push(entity);


### PR DESCRIPTION
## Summary
- add tooltip element to layout and style it
- parse field entity, property, and type from visual JSON
- display field info on hover via custom tooltip

## Testing
- `node -c renderer.js`

------
https://chatgpt.com/codex/tasks/task_e_68729222f07883269ce024385d3eb125